### PR TITLE
use 'mode' consistently in webpack config

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -63,7 +63,7 @@ module.exports = {
 				}
 			]
 		},
-		mode: process.env.NODE_ENV,
+		mode,
 		performance: {
 			hints: false // it doesn't matter if server.js is large
 		}
@@ -72,6 +72,6 @@ module.exports = {
 	serviceworker: {
 		entry: config.serviceworker.entry(),
 		output: config.serviceworker.output(),
-		mode: process.env.NODE_ENV
+		mode
 	}
 };


### PR DESCRIPTION
This will prevent confusion like [this one](https://stackoverflow.com/q/61988779/3468917) where users want to change `mode` to 'development' by changing the top-level `const mode = process.env.NODE_ENV;` only to realize it has no effect in the `server` and `serviceworker` configurations.